### PR TITLE
Add request_timeout option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,6 +25,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                     ->info('If needed you can specify a proxy that is used when connecting to HipChat.')
                 ->end()
+                ->scalarNode('request_timeout')
+                    ->defaultNull()
+                    ->info('In seconds. To change the default timeout of a HipChat API request.')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
                     ->info('If needed you can specify a proxy that is used when connecting to HipChat.')
                 ->end()
                 ->scalarNode('request_timeout')
-                    ->defaultNull()
+                    ->defaultValue(15)
                     ->info('In seconds. To change the default timeout of a HipChat API request.')
                 ->end()
             ->end();

--- a/DependencyInjection/MannewHipchatExtension.php
+++ b/DependencyInjection/MannewHipchatExtension.php
@@ -39,5 +39,9 @@ class MannewHipchatExtension extends Extension
             'mannew_hipchat.proxy_address',
             $config['proxy_address']
         );
+        $container->setParameter(
+            'mannew_hipchat.request_timeout',
+            $config['request_timeout']
+        );
     }
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mannew_hipchat:
 	auth_token: YOUR_HIPCHAT_AUTH_TOKEN_HERE
 	verify_ssl: true    # optional
 	proxy_address: ~    # optional
-	request_timeout: ~  # in seconds, optional
+	request_timeout: 15 # in seconds, optional
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Update your config.yml to contain the a section for this bundle.
 ```yaml
 mannew_hipchat:
 	auth_token: YOUR_HIPCHAT_AUTH_TOKEN_HERE
-	verify_ssl: true  # optional
-	proxy_address: ~  # optional
+	verify_ssl: true    # optional
+	proxy_address: ~    # optional
+	request_timeout: ~  # in seconds, optional
 ```
 
 ## Usage

--- a/Resources/config/hipchat.xml
+++ b/Resources/config/hipchat.xml
@@ -15,6 +15,9 @@
             <call method="set_proxy">
                 <argument>%mannew_hipchat.proxy_address%</argument>
             </call>
+            <call method="set_request_timeout">
+                <argument>%mannew_hipchat.request_timeout%</argument>
+            </call>
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/MannewHipchatExtensionTest.php
+++ b/Tests/DependencyInjection/MannewHipchatExtensionTest.php
@@ -103,7 +103,7 @@ class MannewHipchatExtensionTest extends \PHPUnit_Framework_TestCase
         $container = $this->getEmptyTestContainer();
         $this->loadConfigIntoContainer($config, $container);
 
-        $this->assertContainerParameterEquals($container, 'request_timeout', null);
+        $this->assertContainerParameterEquals($container, 'request_timeout', 15);
     }
 
     /**

--- a/Tests/DependencyInjection/MannewHipchatExtensionTest.php
+++ b/Tests/DependencyInjection/MannewHipchatExtensionTest.php
@@ -82,6 +82,30 @@ class MannewHipchatExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertContainerParameterEquals($container, 'proxy_address', null);
     }
 
+    public function testLoadConfigWithRequestTimeoutOption()
+    {
+        $timeout = 60;
+        $config = array(
+            'request_timeout'   => $timeout,
+            'auth_token'        => uniqid(),
+        );
+        $container = $this->getEmptyTestContainer();
+        $this->loadConfigIntoContainer($config, $container);
+
+        $this->assertContainerParameterEquals($container, 'request_timeout', $timeout);
+    }
+
+    public function testLoadConfigWithoutRequestTimeoutOption()
+    {
+        $config = array(
+            'auth_token'        => uniqid(),
+        );
+        $container = $this->getEmptyTestContainer();
+        $this->loadConfigIntoContainer($config, $container);
+
+        $this->assertContainerParameterEquals($container, 'request_timeout', null);
+    }
+
     /**
      * @param ContainerBuilder $container
      * @param string $parameterName

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Bundle to integrate the HipChat PHP library for their REST API.",
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "hipchat/hipchat-php": ">=1.0.0"
+        "hipchat/hipchat-php": "~1.4"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This PR implement the set_request_timeout option I introduced on https://github.com/hipchat/hipchat-php/pull/23.

I change the dependencies requirements to `"hipchat/hipchat-php": "~1.4"`.

Please wait the new stable version before merge this PR. This won't work now. Travis should be restarted when it will be done.

Don't hesitate to support my new tag asking here: https://github.com/hipchat/hipchat-php/pull/23#issuecomment-97248847 :+1: 

Regards