### PR TITLE
Improve Symfony requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## MAC OS
 .DS_Store
 
+/composer.lock
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
@@ -10,11 +9,26 @@ php:
   - hhvm
 
 matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION="3.1.*@dev"
   allow_failures:
-    - php: 7.0
-    - php: hhvm
+    - php: nightly
+    - env: SYMFONY_VERSION="3.1.*@dev"
 
-before_script:
+install:
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer install --dev --prefer-source
 
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,17 @@
     "name": "mannew/hipchat-bundle",
     "description": "Bundle to integrate the HipChat PHP library for their REST API.",
     "require": {
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "~2.1|~3.0",
         "hipchat/hipchat-php": "~1.4"
+    },
+    "require-dev": {
+        "symfony/console": "~2.1|~3.0"
+    },
+    "suggest": {
+        "symfony/console": "To get HipChat commands"
+    },
+    "conflict": {
+        "symfony/console": "<2.1|>=4.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
- Allow Symfony 3
- Fix missing symfony/console dependency
- Test all still supported Symfony versions on Travis
- Remove PHP7 and HHVM from allowed failures

Please make a tag after this PR. Symfony 3.0 is stable now.
